### PR TITLE
Check Boot Mount

### DIFF
--- a/_modules/ash_linux.py
+++ b/_modules/ash_linux.py
@@ -77,8 +77,9 @@ def _modify_grub_file(rmv_fips_arg):
         if not check:
             # No boot= in grub, so find mount where kernel is located.
             boot_mount = _get_boot_mount()
-            # Add boot= argument.
-            grub_args.append('boot={0} '.format(boot_mount))
+            # Add boot= argument if a boot mount exists.
+            if boot_mount:
+                grub_args.append('boot={0} '.format(boot_mount))
 
         check = __salt__['file.search'](filepath, 'fips=1')
         if not check:

--- a/_modules/ash_linux.py
+++ b/_modules/ash_linux.py
@@ -78,7 +78,7 @@ def _modify_grub_file(rmv_fips_arg):
             # No boot= in grub, so find mount where kernel is located.
             boot_mount = _get_boot_mount()
             # Add boot= argument if a boot mount exists.
-            if boot_mount:
+            if boot_mount or boot_mount == '/':
                 grub_args.append('boot={0} '.format(boot_mount))
 
         check = __salt__['file.search'](filepath, 'fips=1')


### PR DESCRIPTION
If boot mount does not exist (i.e., boot is mounted on `/` instead of `/boot`) then do not add the boot token to the GRUB command line.